### PR TITLE
Handle Metamask transactions

### DIFF
--- a/src/pages/Buy/Buy.jsx
+++ b/src/pages/Buy/Buy.jsx
@@ -16,8 +16,7 @@ const Buy = () => {
     setProtectedAmount,
     setTotalLimit,
     setMetamaskEvent,
-    connect_to_user_wallet,
-   
+    connect_to_user_wallet
   } = useContext(setBlockData);
 
   /* using different local and context variables to clear data on view change */
@@ -58,7 +57,7 @@ const Buy = () => {
         .then((d) => setMetamaskEvent(d))
         .catch((error) => {
           console.log("error", error.message);
-          window.alert(error.message)
+          /* the error for the popup is caught in the confirm screen. Need to navigate back to buy. */
           navigate("/buy");
         });
     } else {

--- a/src/pages/Buy/Buy.jsx
+++ b/src/pages/Buy/Buy.jsx
@@ -11,13 +11,13 @@ import { useWeb3React } from "@web3-react/core";
 
 const Buy = () => {
   const navigate = useNavigate();
-
   const {
     setPrice,
     setProtectedAmount,
     setTotalLimit,
     setMetamaskEvent,
-    connect_to_user_wallet
+    connect_to_user_wallet,
+   
   } = useContext(setBlockData);
 
   /* using different local and context variables to clear data on view change */
@@ -55,7 +55,12 @@ const Buy = () => {
       await meth
         .approve(CONTRACT_ADDRESS, library.utils.toBN(_value * 1e8))
         .send({ from: addressOfUser, value: 0 })
-        .then((d) => setMetamaskEvent(d));
+        .then((d) => setMetamaskEvent(d))
+        .catch((error) => {
+          console.log("error", error.message);
+          window.alert(error.message)
+          navigate("/buy");
+        });
     } else {
       console.log("Wallet not connected!");
     }

--- a/src/pages/Protect/Protect.jsx
+++ b/src/pages/Protect/Protect.jsx
@@ -56,11 +56,14 @@ const Protect = (props) => {
       await meth
         .approve(CONTRACT_ADDRESS, library.utils.toBN(_value * 1e18))
         .send({ from: account, value: 0 })
-        .then((d) => setMetamaskEvent(d)).catch((error)=>{
-          console.log("error",error)
-          window.alert(error.message)
-          navigate('/')
-          });
+        .on("sent", () => {
+          console.log("success");
+        })
+        .then((d) => setMetamaskEvent(d))
+        .catch((error) => {
+          /* the error for the popup is caught in the confirm screen. Need to navigate back to protect. */
+          navigate("/protect");
+        });
     } else {
       console.log("Wallet not connected!");
     }

--- a/src/pages/Protect/Protect.jsx
+++ b/src/pages/Protect/Protect.jsx
@@ -9,7 +9,6 @@ import { useNavigate } from "react-router-dom";
 import { useContext, useState, useEffect } from "react";
 import { setBlockData } from "../../ContextAPI/ContextApi";
 import { useWeb3React } from "@web3-react/core";
-
 const Protect = (props) => {
   const navigate = useNavigate();
 
@@ -57,7 +56,11 @@ const Protect = (props) => {
       await meth
         .approve(CONTRACT_ADDRESS, library.utils.toBN(_value * 1e18))
         .send({ from: account, value: 0 })
-        .then((d) => setMetamaskEvent(d));
+        .then((d) => setMetamaskEvent(d)).catch((error)=>{
+          console.log("error",error)
+          window.alert(error.message)
+          navigate('/')
+          });
     } else {
       console.log("Wallet not connected!");
     }

--- a/src/pages/Sections/ConfirmDetails/ConfirmDetails.jsx
+++ b/src/pages/Sections/ConfirmDetails/ConfirmDetails.jsx
@@ -9,6 +9,7 @@ import { useWeb3React } from "@web3-react/core";
 import { useEffect } from "react";
 
 const ConfirmDetails = ({ type }) => {
+  const navigate = useNavigate();
   // getting context
   const {
     price,
@@ -18,7 +19,7 @@ const ConfirmDetails = ({ type }) => {
     setMetamaskEvent
   } = useContext(setBlockData);
   const [dipAmount, setDipAmount] = useState(null);
-  const navigate = useNavigate();
+
 
   /** @dev account  contain  user wallet address ,  library is the web3 */
   const { account, library } = useWeb3React();
@@ -53,7 +54,12 @@ const ConfirmDetails = ({ type }) => {
           library.utils.toBN(dipAmount * 100000000)
         )
         .send({ from: account, value: 0 })
-        .then((d) => setMetamaskEvent(d));
+        .then((d) => setMetamaskEvent(d)) .catch((error)=>{
+        /**  here you will be able to see what  the transaction status from the metamask if it get falied */
+          console.log("error",error)
+          window.alert(error.message)
+          navigate('/')
+          });
     }
   };
 
@@ -84,7 +90,12 @@ const ConfirmDetails = ({ type }) => {
           library.utils.toBN(dipAmount * 100000000)
         )
         .send({ from: addressOfUser, value: 0 })
-        .then((d) => setMetamaskEvent(d));
+        .then((d) => setMetamaskEvent(d)).catch((error)=>{
+      /**  here you will be able to see what  the transaction status from the metamask if it get falied */
+          console.log("error",error)
+          window.alert(error.message)
+          navigate('/buy')
+          });
     }
   };
 

--- a/src/pages/Sections/ConfirmDetails/ConfirmDetails.jsx
+++ b/src/pages/Sections/ConfirmDetails/ConfirmDetails.jsx
@@ -20,7 +20,6 @@ const ConfirmDetails = ({ type }) => {
   } = useContext(setBlockData);
   const [dipAmount, setDipAmount] = useState(null);
 
-
   /** @dev account  contain  user wallet address ,  library is the web3 */
   const { account, library } = useWeb3React();
 
@@ -54,12 +53,12 @@ const ConfirmDetails = ({ type }) => {
           library.utils.toBN(dipAmount * 100000000)
         )
         .send({ from: account, value: 0 })
-        .then((d) => setMetamaskEvent(d)) .catch((error)=>{
-        /**  here you will be able to see what  the transaction status from the metamask if it get falied */
-          console.log("error",error)
-          window.alert(error.message)
-          navigate('/')
-          });
+        .then((d) => setMetamaskEvent(d))
+        .catch((error) => {
+          /**  here you will be able to see what  the transaction status from the metamask if it get falied */
+          console.log("error", error);
+          navigate(`/${type?.toLowerCase()}`);
+        });
     }
   };
 
@@ -90,12 +89,12 @@ const ConfirmDetails = ({ type }) => {
           library.utils.toBN(dipAmount * 100000000)
         )
         .send({ from: addressOfUser, value: 0 })
-        .then((d) => setMetamaskEvent(d)).catch((error)=>{
-      /**  here you will be able to see what  the transaction status from the metamask if it get falied */
-          console.log("error",error)
-          window.alert(error.message)
-          navigate('/buy')
-          });
+        .then((d) => setMetamaskEvent(d))
+        .catch((error) => {
+          /**  here you will be able to see what  the transaction status from the metamask if it get falied */
+          console.log("error", error);
+          navigate(`/${type?.toLowerCase()}`);
+        });
     }
   };
 

--- a/src/pages/Sections/CreatedDetails/CreatedDetails.jsx
+++ b/src/pages/Sections/CreatedDetails/CreatedDetails.jsx
@@ -16,7 +16,6 @@ const CreatedDetails = ({ type }) => {
         <Link to={"/protect"} onClick={() => setMetamaskEvent(undefined)}>
           <Sprite id="close" width={18} height={18} />
         </Link>
-        {console.log(metamaskEvent)}
       </div>
       <div className={`order-details`}>
         <Typography variant="h5">{type}</Typography>

--- a/src/pages/Sections/RedeemBox/RedeemBox.jsx
+++ b/src/pages/Sections/RedeemBox/RedeemBox.jsx
@@ -5,13 +5,12 @@ import { setBlockData } from "../../../ContextAPI/ContextApi";
 import { WETH_ADDRESS } from "../../../utils/constants";
 import { useWeb3React } from "@web3-react/core";
 
-
 const RedeemBox = ({ type }) => {
   const { stopLoos_Contract, setMetamaskEvent } = useContext(setBlockData);
-  const { account} = useWeb3React();
+  const { account } = useWeb3React();
   const [withdraw_Token, setwithdraw_Token] = useState();
   const [disableButton, setDisableButton] = useState();
- 
+
   /**
    * @function viewBalances - this function will return the asset's value  that is associate with the user address.
    * @param {user wallet address } addressOfUser
@@ -46,7 +45,6 @@ const RedeemBox = ({ type }) => {
         setDisableButton(false);
         /**  here you will be able to see what  the transaction status from the metamask if it get falied */
         console.log(e.message);
-        window.alert(e.message)
       });
   };
 
@@ -63,8 +61,8 @@ const RedeemBox = ({ type }) => {
     let userAssetsInfo = await meth.balances(account).call();
     // setting up the token address that  is associate with user in our Smart contract.
     setwithdraw_Token(userAssetsInfo);
-    }
-    
+  };
+
   useEffect(() => {
     getBalanceInfo();
   }, []);
@@ -91,7 +89,10 @@ const RedeemBox = ({ type }) => {
             </Typography>
           </div> */}
 
-        <Button onClick={() => withdraw(account)} disabled={ withdraw_Token?._amt === "0" || disableButton }>
+        <Button
+          onClick={() => withdraw(account)}
+          disabled={withdraw_Token?._amt === "0" || disableButton}
+        >
           {disableButton ? (
             "Confirmation Pending"
           ) : (

--- a/src/pages/Sections/RedeemBox/RedeemBox.jsx
+++ b/src/pages/Sections/RedeemBox/RedeemBox.jsx
@@ -5,12 +5,13 @@ import { setBlockData } from "../../../ContextAPI/ContextApi";
 import { WETH_ADDRESS } from "../../../utils/constants";
 import { useWeb3React } from "@web3-react/core";
 
+
 const RedeemBox = ({ type }) => {
   const { stopLoos_Contract, setMetamaskEvent } = useContext(setBlockData);
-  const { account, library } = useWeb3React();
+  const { account} = useWeb3React();
   const [withdraw_Token, setwithdraw_Token] = useState();
   const [disableButton, setDisableButton] = useState();
-
+ 
   /**
    * @function viewBalances - this function will return the asset's value  that is associate with the user address.
    * @param {user wallet address } addressOfUser
@@ -37,9 +38,16 @@ const RedeemBox = ({ type }) => {
         if (d) {
           setDisableButton(false);
           setMetamaskEvent(d);
+          // once the user Redeem thier asset we must need to disable the Redeem button
+          getBalanceInfo();
         }
       })
-      .catch((e) => setDisableButton(false));
+      .catch((e) => {
+        setDisableButton(false);
+        /**  here you will be able to see what  the transaction status from the metamask if it get falied */
+        console.log(e.message);
+        window.alert(e.message)
+      });
   };
 
   /**
@@ -54,9 +62,9 @@ const RedeemBox = ({ type }) => {
     // meth -  this variable have  all the method that our Smart contract have .
     let userAssetsInfo = await meth.balances(account).call();
     // setting up the token address that  is associate with user in our Smart contract.
-    setwithdraw_Token(userAssetsInfo._token);
-  };
-
+    setwithdraw_Token(userAssetsInfo);
+    }
+    
   useEffect(() => {
     getBalanceInfo();
   }, []);
@@ -82,14 +90,15 @@ const RedeemBox = ({ type }) => {
               <Sprite id="eth" width={14} height={14} /> WETH)
             </Typography>
           </div> */}
-        <Button onClick={() => withdraw(account)} disabled={disableButton}>
+
+        <Button onClick={() => withdraw(account)} disabled={ withdraw_Token?._amt === "0" || disableButton }>
           {disableButton ? (
             "Confirmation Pending"
           ) : (
             <>
               Redeem
               <br />
-              {withdraw_Token === WETH_ADDRESS ? "WETH" : "USDC"}
+              {withdraw_Token?._token === WETH_ADDRESS ? "WETH" : "USDC"}
             </>
           )}
         </Button>

--- a/src/wrapper/Wrapper.jsx
+++ b/src/wrapper/Wrapper.jsx
@@ -5,7 +5,7 @@ import Content from "./Content/Content";
 import { setBlockData } from "../ContextAPI/ContextApi";
 import { injectors } from "../wallet/connectors";
 import { useWeb3React } from "@web3-react/core";
-import { useNavigate } from "react-router-dom";
+
 const Wrapper = () => {
   /* context values */
   const [assetsAddress, setAssetsAddress] = useState("eth");
@@ -15,7 +15,6 @@ const Wrapper = () => {
   const [stopLoos_Contract, setstopLoos_Contract] = useState();
   const [type, settype] = useState();
   const [metamaskEvent, setMetamaskEvent] = useState();
-  const [history, sethistory] = useState()
   const { activate } = useWeb3React();
 
   /**
@@ -30,32 +29,33 @@ const Wrapper = () => {
   }
 
   return (
-    <setBlockData.Provider
-      value={{
-        price,
-        setPrice,
-        protectedAmount,
-        setProtectedAmount,
-        totalLimit,
-        setTotalLimit,
-        assetsAddress,
-        setAssetsAddress,
-        type,
-        settype,
-        stopLoos_Contract,
-        setstopLoos_Contract,
-        connect_to_user_wallet,
-        metamaskEvent,
-        setMetamaskEvent,
-        history, sethistory
-      }}
-    >
-      <Box style={{ height: "100vh" }}>
-        <Header />
-        <Toolbar />
-        <Content />
-      </Box>
-    </setBlockData.Provider>
+    <>
+      <setBlockData.Provider
+        value={{
+          price,
+          setPrice,
+          protectedAmount,
+          setProtectedAmount,
+          totalLimit,
+          setTotalLimit,
+          assetsAddress,
+          setAssetsAddress,
+          type,
+          settype,
+          stopLoos_Contract,
+          setstopLoos_Contract,
+          connect_to_user_wallet,
+          metamaskEvent,
+          setMetamaskEvent
+        }}
+      >
+        <Box style={{ height: "100vh" }}>
+          <Header />
+          <Toolbar />
+          <Content />
+        </Box>
+      </setBlockData.Provider>
+    </>
   );
 };
 

--- a/src/wrapper/Wrapper.jsx
+++ b/src/wrapper/Wrapper.jsx
@@ -5,7 +5,7 @@ import Content from "./Content/Content";
 import { setBlockData } from "../ContextAPI/ContextApi";
 import { injectors } from "../wallet/connectors";
 import { useWeb3React } from "@web3-react/core";
-
+import { useNavigate } from "react-router-dom";
 const Wrapper = () => {
   /* context values */
   const [assetsAddress, setAssetsAddress] = useState("eth");
@@ -15,7 +15,7 @@ const Wrapper = () => {
   const [stopLoos_Contract, setstopLoos_Contract] = useState();
   const [type, settype] = useState();
   const [metamaskEvent, setMetamaskEvent] = useState();
-
+  const [history, sethistory] = useState()
   const { activate } = useWeb3React();
 
   /**
@@ -47,6 +47,7 @@ const Wrapper = () => {
         connect_to_user_wallet,
         metamaskEvent,
         setMetamaskEvent,
+        history, sethistory
       }}
     >
       <Box style={{ height: "100vh" }}>


### PR DESCRIPTION
This PR solve Bug's in The master code. 

1. Issue before this PR  -
 - If the user **Reject the transactions** or **transactions fail** we were not handling them.
 - On the manage section if the user has **no balance** in Cruzie Then the user's were **allowed to click on the Redeem button **.
2. Issue solved in this PR - 

 -   If the user **Reject the transactions** or **transactions fail**  Then we are redirecting the user to the Protect page or buy 
       that is if the User comes from the **Buy section** then after the  Rejection or falling of the transactions we are 
       **redirecting** the user on Buy and if the user comes from the Protect then we are redirecting the user to Protect.
 -    Showing a pop of error about the transaction failed. what is the error?  is that the user dined the transaction or it is a smart 
      contract error also logging out the error into the console. (we can remove that console log if the team decide to remove it) 
  - On the manage section if the user has no balance then in Cruzie the user would not allow clicking on the Redeem button.
3. Remaining task  - 
 -  shows a UI based error pop-up rejection of the transaction or transactions fail.
 -  show the user why did he redirect to the protect/buy page.
 -  making redirecting to protect/buy page smoothly after the rejection of the transaction or transactions fail.
  

